### PR TITLE
ENH: improved type support for numpy arrays

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
   tests:
     name: Tests
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  tests:
+    name: Tests
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: pip install '.[test]'
+    - run: pytest --pyargs healpix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install '.[test]'
-    - run: pytest --pyargs healpix
+    - run: pytest -v --pyargs healpix

--- a/python/healpix/__init__.py
+++ b/python/healpix/__init__.py
@@ -2,7 +2,7 @@
 # license: BSD-3-Clause
 '''Python package for HEALPix discretisation of the sphere'''
 
-__version__ = '2023.4'
+__version__ = '2024.1'
 
 
 import numpy as np
@@ -17,6 +17,7 @@ underlying integer type in the C library functions.
 
 '''
 
+
 def is_power_of_two(n):
     '''Return True if n is a power of two, or False otherwise.'''
     return (n & (n-1)) == 0
@@ -28,7 +29,7 @@ def check_nside(nside, nest=False):
         raise ValueError('nside must be a positive integer 1 <= nside <= '
                          f'2^{np.log2(NSIDE_MAX):.0f}')
     if nest and (nside & (nside-1)) != 0:
-        raise ValueError('nside must be power of two in the NEST scheme');
+        raise ValueError('nside must be power of two in the NEST scheme')
 
 
 def thetaphi_from_lonlat(lon, lat, theta=None, phi=None):
@@ -118,6 +119,16 @@ def npix2nside(npix):
     return _chp.npix2nside(npix)
 
 
+def nside2order(nside):
+    """Return the HEALPix order for a given NSIDE parameter."""
+    return _chp.nside2order(nside)
+
+
+def order2nside(order):
+    """Return the NSIDE parameter for a given HEALPix order."""
+    return _chp.order2nside(order)
+
+
 def randang(nside, ipix, nest=False, lonlat=False, rng=None):
     '''Sample random spherical coordinates from the given HEALPix pixels.
 
@@ -191,29 +202,28 @@ def ring2nest(nside, ipix):
 def uniq2pix(uniq, nest=False):
     '''Convert from UNIQ to RING or NEST pixel scheme.
 
-    Returns a tuple `nside, ipix` of resolution parameters and pixel
-    indices in the RING scheme (if `nest` is false, the default) or the
-    NEST scheme (if `nest` is true).
+    Returns a tuple `order, ipix` of HEALPix orders and pixel indices in
+    the RING scheme (if `nest` is false, the default) or the NEST scheme
+    (if `nest` is true).
 
     '''
     if nest:
-        nside, ipix = _chp.uniq2nest(uniq)
+        order, ipix = _chp.uniq2nest(uniq)
     else:
-        nside, ipix = _chp.uniq2ring(uniq)
-    return nside, ipix
+        order, ipix = _chp.uniq2ring(uniq)
+    return order, ipix
 
 
-def pix2uniq(nside, ipix, nest=False):
+def pix2uniq(order, ipix, nest=False):
     '''Convert RING or NEST to UNIQ pixel scheme.
 
-    Returns a pixel index in the UNIQ scheme for each pair of resolution
-    parameter `nside` and pixel index `ipix` in the RING scheme (if
-    `nest` is false, the default) or the NEST scheme (if `nest` is
-    true).
+    Returns a pixel index in the UNIQ scheme for each pair of HEALPix
+    order `order` and pixel index `ipix` in the RING scheme (if `nest`
+    is false, the default) or the NEST scheme (if `nest` is true).
 
     '''
     if nest:
-        uniq = _chp.nest2uniq(nside, ipix)
+        uniq = _chp.nest2uniq(order, ipix)
     else:
-        uniq = _chp.ring2uniq(nside, ipix)
+        uniq = _chp.ring2uniq(order, ipix)
     return uniq

--- a/python/healpix/test/conftest.py
+++ b/python/healpix/test/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 import numpy as np
 
-np.random.seed(12345)
-
 
 def fixture_get(request, name, default):
     if name in request.fixturenames:
@@ -61,3 +59,8 @@ def base_pixel_vec(request):
     y = np.array([a, a, -a, -a, 0, 1, 0, -1, a, a, -a, -a])
     z = np.array([b, b, b, b, 0, 0, 0, 0, -b, -b, -b, -b])
     return x, y, z
+
+
+@pytest.fixture(scope="session")
+def rng():
+    return np.random.default_rng(12345)

--- a/python/healpix/test/conftest.py
+++ b/python/healpix/test/conftest.py
@@ -4,10 +4,6 @@ import numpy as np
 np.random.seed(12345)
 
 
-def is_power_of_two(n):
-    return (n & (n-1)) == 0
-
-
 def fixture_get(request, name, default):
     if name in request.fixturenames:
         return request.getfixturevalue(name)
@@ -15,13 +11,21 @@ def fixture_get(request, name, default):
         return default
 
 
-@pytest.fixture(params=[1, 15, 16, 128])
+@pytest.fixture(params=[1, 4, 16, 64])
 def nside(request):
     nside = request.param
-    if (fixture_get(request, 'nest', False) or request.node.get_closest_marker('nest')) \
-            and not is_power_of_two(nside):
-        pytest.skip(reason='nside is not power of two')
     return nside
+
+
+@pytest.fixture(params=[1, 3, 4, 15, 16, 63, 64])
+def nside_dirty(request):
+    nside = request.param
+    return nside
+
+
+@pytest.fixture
+def order(nside):
+    return nside.bit_length() - 1
 
 
 @pytest.fixture(params=[True, False])
@@ -57,8 +61,3 @@ def base_pixel_vec(request):
     y = np.array([a, a, -a, -a, 0, 1, 0, -1, a, a, -a, -a])
     z = np.array([b, b, b, b, 0, 0, 0, 0, -b, -b, -b, -b])
     return x, y, z
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-            'markers', 'nest: mark test as using the NEST scheme')

--- a/python/healpix/test/test_chealpix.py
+++ b/python/healpix/test/test_chealpix.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 import numpy.testing as npt
 
@@ -21,75 +20,70 @@ def test_vec2ang():
     npt.assert_allclose(phi, np.arctan2(y, x))
 
 
-@pytest.mark.nest
 def test_ang_nest(nside):
     from chealpix import ang2nest, nest2ang
     ipix = np.arange(12*nside**2)
     npt.assert_array_equal(ang2nest(nside, *nest2ang(nside, ipix)), ipix)
 
 
-def test_ang_ring(nside):
+def test_ang_ring(nside_dirty):
     from chealpix import ang2ring, ring2ang
-    ipix = np.arange(12*nside**2)
-    npt.assert_array_equal(ang2ring(nside, *ring2ang(nside, ipix)), ipix)
+    ipix = np.arange(12*nside_dirty**2)
+    npt.assert_array_equal(ang2ring(nside_dirty, *ring2ang(nside_dirty, ipix)), ipix)
 
 
-@pytest.mark.nest
 def test_vec_nest(nside):
     from chealpix import vec2nest, nest2vec
     ipix = np.arange(12*nside**2)
     npt.assert_array_equal(vec2nest(nside, *nest2vec(nside, ipix)), ipix)
 
 
-def test_vec_ring(nside):
+def test_vec_ring(nside_dirty):
     from chealpix import vec2ring, ring2vec
-    ipix = np.arange(12*nside**2)
-    npt.assert_array_equal(vec2ring(nside, *ring2vec(nside, ipix)), ipix)
+    ipix = np.arange(12*nside_dirty**2)
+    npt.assert_array_equal(vec2ring(nside_dirty, *ring2vec(nside_dirty, ipix)), ipix)
 
 
-@pytest.mark.nest
 def test_ang_nest_uv(nside):
     from chealpix import ang2nest_uv, nest2ang_uv
     ipix = np.arange(12*nside**2)
     u, v = np.random.rand(2, ipix.size)
     result = ang2nest_uv(nside, *nest2ang_uv(nside, ipix, u, v))
     npt.assert_array_equal(result[0], ipix)
-    npt.assert_allclose(result[1], u)
-    npt.assert_allclose(result[2], v)
+    npt.assert_allclose(result[1], u, rtol=1e-6)
+    npt.assert_allclose(result[2], v, rtol=1e-6)
 
 
-def test_ang_ring_uv(nside):
+def test_ang_ring_uv(nside_dirty):
     from chealpix import ang2ring_uv, ring2ang_uv
-    ipix = np.arange(12*nside**2)
+    ipix = np.arange(12*nside_dirty**2)
     u, v = np.random.rand(2, ipix.size)
-    result = ang2ring_uv(nside, *ring2ang_uv(nside, ipix, u, v))
+    result = ang2ring_uv(nside_dirty, *ring2ang_uv(nside_dirty, ipix, u, v))
     npt.assert_array_equal(result[0], ipix)
-    npt.assert_allclose(result[1], u)
-    npt.assert_allclose(result[2], v)
+    npt.assert_allclose(result[1], u, rtol=1e-6)
+    npt.assert_allclose(result[2], v, rtol=1e-6)
 
 
-@pytest.mark.nest
 def test_vec_nest_uv(nside):
     from chealpix import vec2nest_uv, nest2vec_uv
     ipix = np.arange(12*nside**2)
     u, v = np.random.rand(2, ipix.size)
     result = vec2nest_uv(nside, *nest2vec_uv(nside, ipix, u, v))
     npt.assert_array_equal(result[0], ipix)
-    npt.assert_allclose(result[1], u)
-    npt.assert_allclose(result[2], v)
+    npt.assert_allclose(result[1], u, rtol=1e-6)
+    npt.assert_allclose(result[2], v, rtol=1e-6)
 
 
-def test_vec_ring_uv(nside):
+def test_vec_ring_uv(nside_dirty):
     from chealpix import vec2ring_uv, ring2vec_uv
-    ipix = np.arange(12*nside**2)
+    ipix = np.arange(12*nside_dirty**2)
     u, v = np.random.rand(2, ipix.size)
-    result = vec2ring_uv(nside, *ring2vec_uv(nside, ipix, u, v))
+    result = vec2ring_uv(nside_dirty, *ring2vec_uv(nside_dirty, ipix, u, v))
     npt.assert_array_equal(result[0], ipix)
-    npt.assert_allclose(result[1], u)
-    npt.assert_allclose(result[2], v)
+    npt.assert_allclose(result[1], u, rtol=1e-6)
+    npt.assert_allclose(result[2], v, rtol=1e-6)
 
 
-@pytest.mark.nest
 def test_nest_ring(nside):
     from chealpix import nest2ring, ring2nest
     ipix = np.arange(12*nside**2)
@@ -97,14 +91,14 @@ def test_nest_ring(nside):
     npt.assert_array_equal(ring2nest(nside, nest2ring(nside, ipix)), ipix)
 
 
-def test_nside2npix(nside):
+def test_nside2npix(nside_dirty):
     from chealpix import nside2npix
-    assert nside2npix(nside) == 12*nside**2
+    assert nside2npix(nside_dirty) == 12*nside_dirty**2
 
 
-def test_npix2nside(nside):
+def test_npix2nside(nside_dirty):
     from chealpix import npix2nside
-    assert npix2nside(12*nside**2) == nside
+    assert npix2nside(12*nside_dirty**2) == nside_dirty
 
 
 def test_npix2nside_invalid():
@@ -113,19 +107,38 @@ def test_npix2nside_invalid():
     assert npix2nside(49) == -1
 
 
-@pytest.mark.nest
-def test_uniq_nest(nside):
+def test_nside2order(nside, order):
+    from chealpix import nside2order
+    assert nside2order(nside) == order
+
+
+def test_nside2order_invalid():
+    from chealpix import nside2order
+    assert nside2order(-1) == -1
+    assert nside2order(3) == -1
+
+
+def test_order2nside(nside, order):
+    from chealpix import order2nside
+    assert order2nside(order) == nside
+
+
+def test_order2nside_invalid():
+    from chealpix import order2nside
+    assert order2nside(-1) == -1
+
+
+def test_uniq_nest(order):
     from chealpix import uniq2nest, nest2uniq
-    ipix = np.arange(12*nside**2)
-    nside_out, ipix_out = uniq2nest(nest2uniq(nside, ipix))
-    npt.assert_array_equal(nside_out, nside)
+    ipix = np.arange(12 * (1 << 2*order))
+    order_out, ipix_out = uniq2nest(nest2uniq(order, ipix))
+    npt.assert_array_equal(order_out, order)
     npt.assert_array_equal(ipix_out, ipix)
 
 
-@pytest.mark.nest
-def test_uniq_ring(nside):
+def test_uniq_ring(order):
     from chealpix import uniq2ring, ring2uniq
-    ipix = np.arange(12*nside**2)
-    nside_out, ipix_out = uniq2ring(ring2uniq(nside, ipix))
-    npt.assert_array_equal(nside_out, nside)
+    ipix = np.arange(12 * (1 << 2*order))
+    order_out, ipix_out = uniq2ring(ring2uniq(order, ipix))
+    npt.assert_array_equal(order_out, order)
     npt.assert_array_equal(ipix_out, ipix)

--- a/python/healpix/test/test_healpix.py
+++ b/python/healpix/test/test_healpix.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 import numpy.testing as npt
 
@@ -77,11 +76,12 @@ def test_vec_pix(nside, nest):
 
 def test_uniq_pix(nest):
     from healpix import uniq2pix, pix2uniq, ring2nest
-    nside = 2**np.random.randint(0, 30, 1000)
+    order = np.random.randint(0, 30, 1000)
+    nside = 1 << order
     ipix = np.random.randint(0, 12*nside**2)
     ipnest = ipix if nest else [ring2nest(ns, ip) for ns, ip in zip(nside, ipix)]
-    uniq = pix2uniq(nside, ipix, nest)
+    uniq = pix2uniq(order, ipix, nest)
     npt.assert_array_equal(uniq, 4*nside**2 + ipnest)
-    nside_out, ipix_out = uniq2pix(uniq, nest)
-    npt.assert_array_equal(nside_out, nside)
+    order_out, ipix_out = uniq2pix(uniq, nest)
+    npt.assert_array_equal(order_out, order)
     npt.assert_array_equal(ipix_out, ipix)

--- a/python/healpix/test/test_healpix.py
+++ b/python/healpix/test/test_healpix.py
@@ -4,17 +4,17 @@ import numpy.testing as npt
 from . import assert_shape
 
 
-def test_ang2vec(lonlat, size):
+def test_ang2vec(lonlat, size, rng):
     from healpix import ang2vec
     if lonlat:
-        theta_lon = np.random.uniform(0, 360, size=size)
-        phi_lat = np.random.uniform(-90, 90, size=size)
+        theta_lon = rng.uniform(0, 360, size=size)
+        phi_lat = rng.uniform(-90, 90, size=size)
         x_ = np.cos(np.deg2rad(phi_lat))*np.cos(np.deg2rad(theta_lon))
         y_ = np.cos(np.deg2rad(phi_lat))*np.sin(np.deg2rad(theta_lon))
         z_ = np.sin(np.deg2rad(phi_lat))
     else:
-        theta_lon = np.random.uniform(0, np.pi, size=size)
-        phi_lat = np.random.uniform(0, 2*np.pi, size=size)
+        theta_lon = rng.uniform(0, np.pi, size=size)
+        phi_lat = rng.uniform(0, 2*np.pi, size=size)
         x_ = np.sin(theta_lon)*np.cos(phi_lat)
         y_ = np.sin(theta_lon)*np.sin(phi_lat)
         z_ = np.cos(theta_lon)
@@ -27,11 +27,11 @@ def test_ang2vec(lonlat, size):
     assert_shape(z, size)
 
 
-def test_vec2ang(lonlat, size):
+def test_vec2ang(lonlat, size, rng):
     from healpix import vec2ang
-    x = np.random.standard_normal(size)
-    y = np.random.standard_normal(size)
-    z = np.random.standard_normal(size)
+    x = rng.standard_normal(size)
+    y = rng.standard_normal(size)
+    z = rng.standard_normal(size)
     theta_, phi_ = np.arctan2(np.hypot(x, y), z), np.arctan2(y, x)
     if lonlat:
         theta_, phi_ = np.rad2deg(phi_), np.rad2deg(np.pi/2-theta_)
@@ -74,11 +74,11 @@ def test_vec_pix(nside, nest):
     npt.assert_array_equal(vec2pix(nside, *pix2vec(nside, ipix, nest), nest), ipix)
 
 
-def test_uniq_pix(nest):
+def test_uniq_pix(nest, rng):
     from healpix import uniq2pix, pix2uniq, ring2nest
-    order = np.random.randint(0, 30, 1000)
+    order = rng.integers(0, 30, 1000)
     nside = 1 << order
-    ipix = np.random.randint(0, 12*nside**2)
+    ipix = rng.integers(0, 12*nside**2)
     ipnest = ipix if nest else [ring2nest(ns, ip) for ns, ip in zip(nside, ipix)]
     uniq = pix2uniq(order, ipix, nest)
     npt.assert_array_equal(uniq, 4*nside**2 + ipnest)

--- a/python/reference.txt
+++ b/python/reference.txt
@@ -17,15 +17,20 @@ FUNCTIONS
     
     nside2npix(nside)
     
+    nside2order(nside)
+        Return the HEALPix order for a given NSIDE parameter.
+    
+    order2nside(order)
+        Return the NSIDE parameter for a given HEALPix order.
+    
     pix2ang(nside, ipix, nest=False, lonlat=False)
     
-    pix2uniq(nside, ipix, nest=False)
+    pix2uniq(order, ipix, nest=False)
         Convert RING or NEST to UNIQ pixel scheme.
         
-        Returns a pixel index in the UNIQ scheme for each pair of resolution
-        parameter `nside` and pixel index `ipix` in the RING scheme (if
-        `nest` is false, the default) or the NEST scheme (if `nest` is
-        true).
+        Returns a pixel index in the UNIQ scheme for each pair of HEALPix
+        order `order` and pixel index `ipix` in the RING scheme (if `nest`
+        is false, the default) or the NEST scheme (if `nest` is true).
     
     pix2vec(nside, ipix, nest=False)
     
@@ -64,9 +69,9 @@ FUNCTIONS
     uniq2pix(uniq, nest=False)
         Convert from UNIQ to RING or NEST pixel scheme.
         
-        Returns a tuple `nside, ipix` of resolution parameters and pixel
-        indices in the RING scheme (if `nest` is false, the default) or the
-        NEST scheme (if `nest` is true).
+        Returns a tuple `order, ipix` of HEALPix orders and pixel indices in
+        the RING scheme (if `nest` is false, the default) or the NEST scheme
+        (if `nest` is true).
     
     vec2ang(x, y, z, lonlat=False)
     
@@ -76,7 +81,7 @@ DATA
     NSIDE_MAX = 536870912
 
 VERSION
-    2023.4
+    2024.1
 
 
 Help on module chealpix:
@@ -101,7 +106,7 @@ FUNCTIONS
     
     nest2ring(nside, ipnest, ipring=None, /)
     
-    nest2uniq(nside, ipix, uniq=None, /)
+    nest2uniq(order, ipix, uniq=None, /)
     
     nest2vec(nside, ipix, x=None, y=None, z=None, /)
     
@@ -111,21 +116,25 @@ FUNCTIONS
     
     nside2npix(nside, /)
     
+    nside2order(nside, /)
+    
+    order2nside(order, /)
+    
     ring2ang(nside, ipix, theta=None, phi=None, /)
     
     ring2ang_uv(nside, ipix, u, v, theta=None, phi=None, /)
     
     ring2nest(nside, ipring, ipnest=None, /)
     
-    ring2uniq(nside, ipix, uniq=None, /)
+    ring2uniq(order, ipix, uniq=None, /)
     
     ring2vec(nside, ipix, x=None, y=None, z=None, /)
     
     ring2vec_uv(nside, ipix, u, v, x=None, y=None, z=None, /)
     
-    uniq2nest(uniq, nside=None, ipix=None, /)
+    uniq2nest(uniq, order=None, ipix=None, /)
     
-    uniq2ring(uniq, nside=None, ipix=None, /)
+    uniq2ring(uniq, order=None, ipix=None, /)
     
     vec2ang(nside, x, y, z, theta=None, phi=None, /)
     
@@ -141,6 +150,6 @@ DATA
     NSIDE_MAX = 536870912
 
 VERSION
-    2023.4
+    2024.1
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,7 @@ packages =
 python_requires = >=3.6
 install_requires =
     numpy
+
+[options.extras_require]
+test =
+    pytest

--- a/src/healpix.h
+++ b/src/healpix.h
@@ -121,6 +121,14 @@ int64_t nside2npix(int64_t nside);
 int64_t npix2nside(int64_t npix);
 
 
+// Returns log2(nside).
+int8_t nside2order(int64_t nside);
+
+
+// Returns log2(npix).
+int64_t order2nside(int8_t order);
+
+
 // Returns the angle (in radians) between the vectors v1 and v2.
 // The result is accurate even for angles close to 0 and pi.
 double vec_angle(t_vec v1, t_vec v2);
@@ -164,9 +172,9 @@ t_vec ring2vec_uv(int64_t nside, int64_t ipix, double u, double v);
 // Conversions to UNIQ pixel index scheme
 
 
-// Describe a pixel index in RING or NEST scheme and its nside parameter
+// Describe a pixel index in RING or NEST scheme and its order parameter
 typedef struct {
-    int64_t nside;
+    int8_t order;
     int64_t ipix;
 } t_pix;
 
@@ -179,12 +187,12 @@ t_pix uniq2nest(int64_t uniq);
 t_pix uniq2ring(int64_t uniq);
 
 
-// Convert from NEST scheme and nside parameter to UNIQ
-int64_t nest2uniq(int64_t nside, int64_t ipix);
+// Convert from NEST scheme and order parameter to UNIQ
+int64_t nest2uniq(int8_t order, int64_t ipix);
 
 
-// Convert from RING scheme and nside parameter to UNIQ
-int64_t ring2uniq(int64_t nside, int64_t ipix);
+// Convert from RING scheme and order parameter to UNIQ
+int64_t ring2uniq(int8_t order, int64_t ipix);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This change improves type support for numpy arrays in two ways:

1. Do not require numpy arrays to be aligned and contiguous. This fixes an issue with conversion from or to arrays of different int width.
2. Use numpy data types in C interface. Instead of treating numpy array data as the C types `int64_t` etc., the code now uses `npy_int64` etc. to match the `NPY_INT64` dtype descriptor.

A related change is to use `order` instead of `nside` for the UNIQ pixel indexing functions. This is a backward-incompatible change, but the functions are fairly new and not used much.