### PR TITLE
gh-42: setuptools minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools >= 61.0", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Require the minimum setuptools version for reading pyproject.toml at build time.

Closes: #42