### PR TITLE
gh-44: require Python>=3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "numpy",
 ]


### PR DESCRIPTION
Bump the minimum Python version to 3.7.

Closes: #44