### PR TITLE
TST: Fix macos-latest and Python 3.7 test error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - windows-latest
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
-          - os: macos-latest
+          - runs-on: macos-latest
             python-version: '3.7'
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
           - macos-latest
           - windows-latest
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Exclude the combination of `macos-latest` and `python-version==3.7` from running tests.

Fixes: gh-50