### PR TITLE
force numpy>2.0 instead of deprecated oldest-supported-numpy during build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools >= 61.0", "numpy>=2.0"]
+requires = ["setuptools >= 61.0", 
+            "numpy>=2.0;python_version>='3.9'",
+            "oldest-supported-numpy;python_version<'3.9'"
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0", "oldest-supported-numpy"]
+requires = ["setuptools >= 61.0", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
closes #54 (specifically if a release is done somewhat soon after merging this)

After toying a bit with the local installation, this change actually resolved the error.

apparently [oldest-supported-numpy is deprecated](https://github.com/scipy/oldest-supported-numpy?tab=readme-ov-file#deprecation-notice-for-numpy-20)

It shouldn't break installs as this is mentioned [on the numpy docs](https://numpy.org/devdocs/dev/depending_on_numpy.html#build-time-dependency) nowadays:
> By default, NumPy will expose an API that is backwards compatible with the oldest NumPy version that supports the currently oldest compatible Python version. NumPy 1.25.0 supports Python 3.9 and higher and NumPy 1.19 is the first version to support Python 3.9. Thus, we guarantee that, when using defaults, NumPy 1.25 will expose a C-API compatible with NumPy 1.19. (the exact version is set within NumPy-internal header files). 

Which wasn't the case before numpy `1.25`, and the original reason for the existence of `oldest-supported-numpy`