### PR TITLE
gh-63: improved manual triggering of builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -11,6 +11,31 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Build version from
+        required: true
+        type: string
+      build:
+        description: CIBW_BUILD
+        required: true
+        type: string
+        default: 'cp*'
+      skip:
+        description: CIBW_SKIP
+        required: true
+        type: string
+        default: ''
+      sdist:
+        description: Build sdist
+        required: true
+        type: boolean
+        default: false
+      upload:
+        description: Upload to PyPI
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   build_wheels:
@@ -23,11 +48,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || '' }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: 'cp*'
+          CIBW_BUILD: ${{ inputs.build || 'cp*' }}
+          CIBW_SKIP: ${{ inputs.skip || '' }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -37,6 +65,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' || inputs.sdist
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +81,11 @@ jobs:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: |
+      always()
+      && (needs.build_wheels.result == 'success' || needs.build_wheels.result == 'skipped')
+      && (needs.build_sdist.result == 'success' || needs.build_sdist.result == 'skipped')
+      && (github.event_name == 'release' && github.event.action == 'published' || inputs.upload)
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,14 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
         exclude:
           - runs-on: macos-latest
             python-version: '3.7'


### PR DESCRIPTION
Allows manually triggered builds to

* build any version using the main branch workflow (i.e., with an updated cibw),
* specify which Python versions to build and skip (`CIBW_BUILD`, `CIBW_SKIP`),
* build or skip the sdist,
* upload to PyPI, or not.

Closes: #63